### PR TITLE
Windows VS2019 build fix: avoided 'and' keyword for logical and.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,8 +484,9 @@ struct MutexWatershed {
         action_counter = 0;
         error_count = 0;
         for (auto& e : edge_list) {
-            if (num_iterations != 0 and num_iterations <= action_counter)
-                finished = false;
+            if (num_iterations != 0)
+                if (num_iterations <= action_counter)
+                    finished = false;
 
             if (!seen_actions(e)) {
                 seen_actions(e) = true;


### PR DESCRIPTION
## Bug description
Building with `conda create -n mws -c conda-forge xtensor-python` breaks with Visual Studio 2019 build tools, and possibly (probably) for other VS versions. The following errors are reported

```
src/main.cpp(487): error C2146: syntax error: missing ')' before identifier 'and'
src/main.cpp(487): error C2065: 'and': undeclared identifier
src/main.cpp(487): error C2146: syntax error: missing ';' before identifier 'num_iterations'
src/main.cpp(487): error C2059: syntax error: ')'
src/main.cpp(488): error C2146: syntax error: missing ';' before identifier 'finished'
```

## Cause
Keyword 'and' for logical and on L487.

## Solution
Removed the keyword and replaced with nested ifs.